### PR TITLE
Set cache dir in session-scoped autouse fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,11 @@
 import pytest
+import os
 import tarfile
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setUp(tmp_path_factory):
+    os.environ["XDG_CACHE_HOME"] = str(tmp_path_factory.mktemp("scratch"))
 
 
 @pytest.fixture


### PR DESCRIPTION
For testing purposes, make sure the cache dir is always a temporary
directory, set this in a session-scoped autouse fixture.  This has
become relevant since unpacking the tgz is done to cache and not to
tmpdir.